### PR TITLE
first event in session

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,6 @@ async function setupPlugin({ config, global }) {
 }
 
 async function processEvent(event, { global, storage }) {
-    if (event.event === 'session_started') {
-        return event
-    }
-
     const THIRTY_MINUTES = 1000 * 60 * 30
 
     const userSeenInLastHalfHour = await cache.get(`user_seen_${event.distinct_id}`)

--- a/index.js
+++ b/index.js
@@ -7,30 +7,30 @@ async function processEvent(event, { global, storage }) {
         return event
     }
 
-    const THIRTY_MINUTES = 1000*60*30
-    const timestamp = event.timestamp || event.data?.timestamp || event.properties?.timestamp || event.now || event.sent_at
-    const userLastSeen = await storage.get(`last_seen_${event.distinct_id}`)
-    let isFirstEventInSession = false
+    const THIRTY_MINUTES = 1000 * 60 * 30
 
-    if (timestamp) {
-        const parsedTimestamp = new Date(timestamp).getTime()
-        const timeSinceLastSeen = parsedTimestamp - (userLastSeen || 0)
-        isFirstEventInSession = timeSinceLastSeen > THIRTY_MINUTES
-        storage.set(`last_seen_${event.distinct_id}`, parsedTimestamp)
+    const userSeenInLastHalfHour = await cache.get(`user_seen_${event.distinct_id}`)
+    const isFirstEventInSession = !!userSeenInLastHalfHour
 
-        if (isFirstEventInSession) {
-            posthog.capture(
-                'session_started', 
-                { 
-                    distinct_id: event.distinct_id, 
-                    time_since_last_seen: timeSinceLastSeen,
-                    timestamp: timestamp, // backdate to when session _actually_ started
-                    trigger_event: event.event
-                }
-            )
-        }
-        
+    if (!userSeenInLastHalfHour) {
+        await cache.set(`user_seen_${event.distinct_id}`, 1)
     }
+
+    await cache.expire(`user_seen_${event.distinct_id}`, THIRTY_MINUTES)
+
+
+    if (event.timestamp && isFirstEventInSession) {
+        posthog.capture(
+            'session_started',
+            {
+                distinct_id: event.distinct_id,
+                time_since_last_seen: timeSinceLastSeen,
+                timestamp: event.timestamp, // backdate to when session _actually_ started
+                trigger_event: event.event
+            }
+        )
+    }
+
 
     event.properties['is_first_event_in_session'] = isFirstEventInSession
 


### PR DESCRIPTION
Checking for the existence of keys in redis rather than a timestamp in postgres to determine a session start

If Redis goes down I guess there's a scenario where there will be `session_started` events in the middle of a session though.
